### PR TITLE
Add format string width

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,15 +144,17 @@ func printTopValues(displayRecord map[string]time.Time, useLock bool) {
 		}
 		if !*noNetstat {
 			if _, ok := activeConn[key]; ok {
-				activeString := fmt.Sprintf(" (active, %d)", activeConn[key])
+				activeString := fmt.Sprintf(" (%2d)", activeConn[key])
 				if !boldLine {
 					connection = fmt.Sprintf("%s%s%s", boldStart, activeString, boldEnd)
 				} else {
 					connection = activeString
 				}
+			} else {
+				connection = "     "
 			}
 		}
-		log.Printf("%s%s%s: %s %d %s %s (from %s, last accessed %s)%s\n", fmtStart, key, connection, humanize.IBytes(total), reqTotal,
+		log.Printf("%s%16s%s: %7s %3d %7s %s (from %s, last accessed %s)%s\n", fmtStart, key, connection, humanize.IBytes(total), reqTotal,
 			humanize.IBytes(average), last, lastUpdateTime, lastAccessTime, fmtEnd)
 		if displayRecord != nil {
 			displayRecord[key] = lastURLAccessDate[key]


### PR DESCRIPTION
Result (with `no-netstat`):

```
2024/04/07 22:47:35   111.22.22.0/24:  26 GiB   6 4.4 GiB /centos/*
2024/04/07 22:47:35 222.222.111.0/24:  21 GiB   2  11 GiB /carla/*
2024/04/07 22:47:35   111.66.44.0/24:  18 GiB  98 183 MiB /Adoptium/17/j*
2024/04/07 22:47:35 111.222.233.0/24:  12 GiB   3 4.2 GiB /carla/*
```

without `no-netstat`:

```
2024/04/07 22:49:38   33.233.33.0/24     : 1.6 GiB   6 278 MiB /pypi/*
2024/04/07 22:49:38  111.222.33.0/24 (11): 1.3 GiB   7 189 MiB /debian/*
2024/04/07 22:49:38  111.22.333.0/24     : 927 MiB   5 186 MiB /anaconda-extra/*
2024/04/07 22:49:38  111.222.33.0/24     : 927 MiB   5 186 MiB /anaconda-extra/*
2024/04/07 22:49:38  11.222.333.0/24     : 927 MiB   5 186 MiB /anaconda-extra/*
2024/04/07 22:49:38 111.222.333.0/24 ( 9): 847 MiB   6 141 MiB /git/*
2024/04/07 22:49:38  111.222.33.0/24     : 845 MiB   5 169 MiB /anaconda-extra/*
2024/04/07 22:49:38  111.22.333.0/24     : 796 MiB   2 398 MiB /anaconda/*
```