### PR TITLE
Add `list parsers` command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/taoky/ayano/pkg/parser"
+)
+
+func listCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list <item>",
+		Short: "List various items",
+		Args:  cobra.NoArgs,
+		RunE:  showHelp,
+	}
+	cmd.AddCommand(listParsersCmd())
+	return cmd
+}
+
+func listParsersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "parsers",
+		Short: "List available log parsers",
+		Args:  cobra.NoArgs,
+	}
+	var all bool
+	cmd.Flags().BoolVarP(&all, "all", "a", false, "Show all parsers")
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		table := tablewriter.NewWriter(cmd.OutOrStdout())
+		table.SetAutoWrapText(false)
+		table.SetAutoFormatHeaders(true)
+		table.SetCenterSeparator("")
+		table.SetColumnSeparator("")
+		table.SetRowLine(false)
+		table.SetRowSeparator("")
+		table.SetTablePadding("  ")
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
+		table.SetHeaderLine(false)
+		table.SetBorder(false)
+		table.SetNoWhiteSpace(true)
+
+		table.SetHeader([]string{"Name", "Description"})
+
+		parsers := parser.All()
+		slices.SortFunc(parsers, func(a, b parser.ParserMeta) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+		for _, p := range parsers {
+			if all || !p.Hidden {
+				table.Append([]string{p.Name, p.Description})
+			}
+		}
+		table.Render()
+		return nil
+	}
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ func RootCmd() *cobra.Command {
 		runCmd(),
 		analyzeCmd(),
 		daemonCmd(),
+		listCmd(),
 	)
 	return rootCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -7,18 +7,21 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/json-iterator/go v1.1.12
 	github.com/nxadm/tail v1.4.11
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/taoky/goaccessfmt v0.0.0-20240824074420-af31a41470aa
-	golang.org/x/sys v0.24.0
+	golang.org/x/sys v0.25.0
 )
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/taoky/goaccessfmt v0.0.0-20240824074420-af31a41470aa h1:+yzNM1meB5B2Yw8FiaP0IeDZf0aSy8fldLxEq5OnW60=
 github.com/taoky/goaccessfmt v0.0.0-20240824074420-af31a41470aa/go.mod h1:TOGR4KBT75UkXmBzXh2rvkmb1dYSKWtGbV5o8MTJ4dM=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
-golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,9 @@ github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/my
 github.com/itchyny/timefmt-go v0.1.6/go.mod h1:RRDZYC5s9ErkjQvTvvU7keJjxUYzIISJGxm9/mAERQg=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -23,8 +26,13 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
@@ -39,6 +47,8 @@ github.com/taoky/goaccessfmt v0.0.0-20240824074420-af31a41470aa/go.mod h1:TOGR4K
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
 golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/pkg/analyze/analyze.go
+++ b/pkg/analyze/analyze.go
@@ -75,7 +75,7 @@ func (c *AnalyzerConfig) InstallFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&c.Absolute, "absolute", "a", c.Absolute, "Show absolute time for each item")
 	flags.StringVarP(&c.LogOutput, "outlog", "o", c.LogOutput, "Change log output file")
 	flags.BoolVarP(&c.NoNetstat, "no-netstat", "", c.NoNetstat, "Do not detect active connections")
-	flags.StringVarP(&c.Parser, "parser", "p", c.Parser, "Log parser (nginx-combined|nginx-json|caddy-json|goaccess)")
+	flags.StringVarP(&c.Parser, "parser", "p", c.Parser, "Log parser (see `ayano list parsers`)")
 	flags.IntVarP(&c.RefreshSec, "refresh", "r", c.RefreshSec, "Refresh interval in seconds")
 	flags.StringVarP(&c.Server, "server", "s", c.Server, "Server IP to filter (nginx-json only)")
 	flags.VarP(&c.SortBy, "sort-by", "S", "Sort result by (size|requests)")

--- a/pkg/parser/caddy.go
+++ b/pkg/parser/caddy.go
@@ -6,11 +6,20 @@ import (
 )
 
 func init() {
-	RegisterParser("caddy-json", func() Parser {
+	newFunc := func() Parser {
 		return CaddyJSONParser{}
+	}
+
+	RegisterParser(ParserMeta{
+		Name:        "caddy-json",
+		Description: "Caddy's default JSON format",
+		F:           newFunc,
 	})
-	RegisterParser("caddy", func() Parser {
-		return CaddyJSONParser{}
+	RegisterParser(ParserMeta{
+		Name:        "caddy",
+		Description: "An alias for `caddy-json`",
+		Hidden:      true,
+		F:           newFunc,
 	})
 }
 

--- a/pkg/parser/goaccess.go
+++ b/pkg/parser/goaccess.go
@@ -8,12 +8,16 @@ import (
 )
 
 func init() {
-	RegisterParser("goaccess", func() Parser {
-		parser, err := GoAccessFormatParser{}.new()
-		if err != nil {
-			log.Fatalln("goaccess init failed (You might need to set GOACCESS_CONFIG env)\n", err)
-		}
-		return parser
+	RegisterParser(ParserMeta{
+		Name:        "goaccess",
+		Description: "GoAccess output format",
+		F: func() Parser {
+			parser, err := GoAccessFormatParser{}.new()
+			if err != nil {
+				log.Fatalln("goaccess init failed (You might need to set GOACCESS_CONFIG env)\n", err)
+			}
+			return parser
+		},
 	})
 }
 

--- a/pkg/parser/nginx-combined.go
+++ b/pkg/parser/nginx-combined.go
@@ -8,11 +8,19 @@ import (
 )
 
 func init() {
-	RegisterParser("nginx-combined", func() Parser {
+	newFunc := func() Parser {
 		return NginxCombinedParser{}
+	}
+	RegisterParser(ParserMeta{
+		Name:        "nginx-combined",
+		Description: "For nginx's default `combined` format",
+		F:           newFunc,
 	})
-	RegisterParser("combined", func() Parser {
-		return NginxCombinedParser{}
+	RegisterParser(ParserMeta{
+		Name:        "combined",
+		Description: "An alias for `nginx-combined`",
+		Hidden:      true,
+		F:           newFunc,
 	})
 }
 

--- a/pkg/parser/nginx-json.go
+++ b/pkg/parser/nginx-json.go
@@ -6,11 +6,19 @@ import (
 )
 
 func init() {
-	RegisterParser("nginx-json", func() Parser {
+	newFunc := func() Parser {
 		return NginxJSONParser{}
+	}
+	RegisterParser(ParserMeta{
+		Name:        "nginx-json",
+		Description: "`nginx-json` format, see README.md for details",
+		F:           newFunc,
 	})
-	RegisterParser("ngx_json", func() Parser {
-		return NginxJSONParser{}
+	RegisterParser(ParserMeta{
+		Name:        "ngx_json",
+		Description: "An alias for `nginx-json`",
+		Hidden:      true,
+		F:           newFunc,
 	})
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -21,21 +21,36 @@ type Parser interface {
 
 type NewFunc func() Parser
 
+type ParserMeta struct {
+	Name        string
+	Description string
+	Hidden      bool
+	F           NewFunc
+}
+
 var (
 	json                  = jsoniter.ConfigCompatibleWithStandardLibrary
 	ErrExpectedIgnoredLog = errors.New("ignored")
 
-	registry = make(map[string]NewFunc)
+	registry = make(map[string]ParserMeta)
 )
 
-func RegisterParser(name string, newFunc NewFunc) {
-	registry[name] = newFunc
+func RegisterParser(m ParserMeta) {
+	registry[m.Name] = m
 }
 
 func GetParser(name string) (Parser, error) {
-	newFunc, ok := registry[name]
+	m, ok := registry[name]
 	if !ok {
 		return nil, errors.New(name)
 	}
-	return newFunc(), nil
+	return m.F(), nil
+}
+
+func All() []ParserMeta {
+	result := make([]ParserMeta, 0, len(registry))
+	for _, m := range registry {
+		result = append(result, m)
+	}
+	return result
 }


### PR DESCRIPTION
```console
$ ./ayano list parsers
NAME            DESCRIPTION                                    
caddy-json      Caddy's default JSON format                     
goaccess        GoAccess output format                          
nginx-combined  For nginx's default `combined` format           
nginx-json      `nginx-json` format, see README.md for details  
```

```console
$ ./ayano list parsers --all
NAME            DESCRIPTION                                    
caddy           An alias for `caddy-json`                       
caddy-json      Caddy's default JSON format                     
combined        An alias for `nginx-combined`                   
goaccess        GoAccess output format                          
nginx-combined  For nginx's default `combined` format           
nginx-json      `nginx-json` format, see README.md for details  
ngx_json        An alias for `nginx-json`                       
```