### PR TITLE
analyze: Group CIDRs with --group

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,18 +10,21 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.9.0
 	github.com/taoky/goaccessfmt v0.0.0-20240824074420-af31a41470aa
 	golang.org/x/sys v0.25.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/taoky/goaccessfmt v0.0.0-20240824074420-af31a41470aa/go.mod h1:TOGR4K
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/pkg/analyze/util.go
+++ b/pkg/analyze/util.go
@@ -73,6 +73,23 @@ func (a *Analyzer) IPPrefix(ip netip.Addr) netip.Prefix {
 	return clientPrefix.Masked()
 }
 
+func AdjacentPrefix(p netip.Prefix) netip.Prefix {
+	bits := p.Bits()
+	if bits == 0 {
+		return p
+	}
+	a := p.Addr()
+	if a.Is4() {
+		addr := a.As4()
+		addr[(bits-1)/8] ^= uint8(1 << (7 - (bits-1)%8))
+		return netip.PrefixFrom(netip.AddrFrom4(addr), bits)
+	} else {
+		addr := a.As16()
+		addr[(bits-1)/8] ^= uint8(1 << (7 - (bits-1)%8))
+		return netip.PrefixFrom(netip.AddrFrom16(addr), bits)
+	}
+}
+
 func TruncateURLPath(input string) string {
 	count := strings.Count(input, "/")
 	if count <= 2 {

--- a/pkg/analyze/utils_test.go
+++ b/pkg/analyze/utils_test.go
@@ -1,0 +1,20 @@
+package analyze
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func assertAdjacentPrefix(t *testing.T, p1, p2 string) {
+	assert.Equal(t, netip.MustParsePrefix(p2), AdjacentPrefix(netip.MustParsePrefix(p1)))
+	assert.Equal(t, netip.MustParsePrefix(p1), AdjacentPrefix(netip.MustParsePrefix(p2)))
+}
+
+func TestAdjacentPrefix(t *testing.T) {
+	assertAdjacentPrefix(t, "1.2.3.0/24", "1.2.2.0/24")
+	assertAdjacentPrefix(t, "1.2.2.0/23", "1.2.0.0/23")
+	assertAdjacentPrefix(t, "2001:db8:114:514::/64", "2001:db8:114:515::/64")
+	assertAdjacentPrefix(t, "2001:db8:114:514::/63", "2001:db8:114:516::/63")
+}


### PR DESCRIPTION
Algorithm:

- Maintain a "grouped keys" bucket
- Start from the sorted keys list (i.e. try to group large items first), for each key:
  - Find its "adjacent part" in the "grouped" bucket
  - If found, try to group the stats recursively
  - If not found, add it unless the bucket is already at capacity, else stop

This algorithm strikes a good balance between accuracy and avoiding too many small items being grouped up into a large one unexpectedly. For example, if there are 256 `/24` IPv4 ranges (within the same `/16`) generating 1 GB traffic and two more `/24` ranges generating 100 GB each, with `-n 2`, the small ranges will not suddenly show up as one `/16` with 256 GB traffic and surpass the more problematic ranges with 100 GB traffic.