### PR TITLE
Add parser for rsync-proxy

### DIFF
--- a/pkg/analyze/analyze.go
+++ b/pkg/analyze/analyze.go
@@ -296,6 +296,10 @@ func (a *Analyzer) handleLine(line []byte) error {
 }
 
 func (a *Analyzer) handleLogItem(logItem parser.LogItem) error {
+	if logItem.Discard {
+		return nil
+	}
+
 	// Filter by server
 	if a.Config.Server != "" && logItem.Server != a.Config.Server {
 		return nil

--- a/pkg/parser/caddy.go
+++ b/pkg/parser/caddy.go
@@ -51,7 +51,7 @@ func ParseCaddyJSON(line []byte) (LogItem, error) {
 		return LogItem{}, err
 	}
 	if logItem.Msg != "handled request" {
-		return LogItem{}, ErrExpectedIgnoredLog
+		return LogItem{Discard: true}, nil
 	}
 	sec, dec := math.Modf(logItem.Timestamp)
 	t := time.Unix(int64(sec), int64(dec*1e9))

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -37,8 +37,6 @@ type ParserMeta struct {
 }
 
 var (
-	ErrExpectedIgnoredLog = errors.New("ignored")
-
 	registry = make(map[string]ParserMeta)
 )
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -12,6 +12,9 @@ type LogItem struct {
 	URL       string
 	Server    string
 	Useragent string
+
+	// Parsers wishing to discard this log item can set Discard to true.
+	Discard bool
 }
 
 type Parser interface {

--- a/pkg/parser/rsync-proxy.go
+++ b/pkg/parser/rsync-proxy.go
@@ -1,0 +1,66 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	goLogTime   = "2006/01/02 15:04:05"
+	listModules = "/"
+)
+
+func init() {
+	newFunc := func() Parser { return ParserFunc(ParseRsyncProxy) }
+	RegisterParser(ParserMeta{
+		Name:        "rsync-proxy",
+		Description: "rsync-proxy's access.log",
+		F:           newFunc,
+	})
+}
+
+func ParseRsyncProxy(line []byte) (LogItem, error) {
+	fields := strings.Fields(string(line))
+	if len(fields) != 9 && len(fields) != 12 {
+		return LogItem{}, fmt.Errorf("invalid format: expected 9 or 12 fields, got %d", len(fields))
+	}
+
+	logTime, err := time.ParseInLocation(goLogTime, fields[0]+" "+fields[1], time.Local)
+	if err != nil {
+		return LogItem{}, fmt.Errorf("invalid log time: %w", err)
+	}
+
+	logItem := LogItem{
+		Client: fields[4],
+		Time:   logTime,
+	}
+
+	switch fields[5] {
+	case "starts":
+		return LogItem{Discard: true}, nil
+	case "finishes":
+		logItem.URL = fields[7]
+		size, err := strconv.ParseUint(strings.TrimSuffix(fields[9], ","), 10, 64)
+		if err != nil {
+			return logItem, fmt.Errorf("invalid size: %w", err)
+		}
+		logItem.Size = size
+	case "requests":
+		if fields[6] == "listing" {
+			logItem.URL = listModules
+			// chop off port
+			if strings.HasPrefix(logItem.Client, "[") {
+				logItem.Client = strings.TrimPrefix(logItem.Client, "[")
+				logItem.Client = strings.Split(logItem.Client, "]")[0]
+			} else {
+				logItem.Client = strings.Split(logItem.Client, ":")[0]
+			}
+		} else {
+			// requests non-existing module
+			logItem.URL = fields[8]
+		}
+	}
+	return logItem, nil
+}

--- a/pkg/parser/rsync-proxy_test.go
+++ b/pkg/parser/rsync-proxy_test.go
@@ -1,0 +1,66 @@
+package parser
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRsyncProxyParser(t *testing.T) {
+	as := assert.New(t)
+	parser, err := GetParser("rsync-proxy")
+	if !as.NoError(err) {
+		return
+	}
+
+	line := `2024/10/01 00:00:00 server.go:279: client 123.45.67.89 starts requesting module ubuntu`
+	log, err := parser.Parse([]byte(line))
+	if as.NoError(err) {
+		as.True(log.Discard)
+	}
+
+	line = `2024/10/01 00:00:00 server.go:279: client 123.45.67.89 finishes module ubuntu (sent: 1841, received: 208)`
+	log, err = parser.Parse([]byte(line))
+	if as.NoError(err) {
+		as.False(log.Discard)
+		as.Equal("123.45.67.89", log.Client)
+		as.Equal("ubuntu", log.URL)
+		as.EqualValues(1841, log.Size)
+		expectedTime := time.Date(2024, 10, 1, 0, 0, 0, 0, time.Local)
+		as.WithinDuration(expectedTime, log.Time, 0)
+	}
+
+	line = `2024/10/01 00:00:00 server.go:279: client 123.45.67.89 requests non-existing module centos`
+	log, err = parser.Parse([]byte(line))
+	if as.NoError(err) {
+		as.False(log.Discard)
+		as.Equal("123.45.67.89", log.Client)
+		as.Equal("centos", log.URL)
+		as.EqualValues(0, log.Size)
+		expectedTime := time.Date(2024, 10, 1, 0, 0, 0, 0, time.Local)
+		as.WithinDuration(expectedTime, log.Time, 0)
+	}
+
+	line = `2024/10/01 00:00:00 server.go:279: client 123.45.67.89:2333 requests listing all modules`
+	log, err = parser.Parse([]byte(line))
+	if as.NoError(err) {
+		as.False(log.Discard)
+		as.Equal("123.45.67.89", log.Client)
+		as.Equal(listModules, log.URL)
+		as.EqualValues(0, log.Size)
+		expectedTime := time.Date(2024, 10, 1, 0, 0, 0, 0, time.Local)
+		as.WithinDuration(expectedTime, log.Time, 0)
+	}
+
+	line = `2024/10/01 00:00:00 server.go:279: client [2001:db8:666:6969::1]:12345 requests listing all modules`
+	log, err = parser.Parse([]byte(line))
+	if as.NoError(err) {
+		as.False(log.Discard)
+		as.Equal("2001:db8:666:6969::1", log.Client)
+		as.Equal(listModules, log.URL)
+		as.EqualValues(0, log.Size)
+		expectedTime := time.Date(2024, 10, 1, 0, 0, 0, 0, time.Local)
+		as.WithinDuration(expectedTime, log.Time, 0)
+	}
+}


### PR DESCRIPTION
Because rsync-proxy produces two lines for normal requests, we need to ignore the "starts requesting module xxx" line, and so I added `Discard bool` for `LogItem`.